### PR TITLE
Revise rolling coin physics for contact point

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,8 +420,8 @@
       const s_dir_raw = sub(zHat, mul(n, dot(n, zHat))); // projection of ẑ onto coin plane
       const hasTilt = (Math.sqrt(Math.max(0, 1 - cosTheta*cosTheta)) > 1e-6);
       const s_dir = hasTilt ? normalize(s_dir_raw) : vec3(0,0,0);
-      const omega_parallel = mul(n, dot(omega_w, n));
-      const v_cm3 = cross(omega_parallel, s_dir);
+      // Pure rolling: v_cm = - ω × r_c with r_c = -R s_dir => v_cm = R (ω × s_dir)
+      const v_cm3 = cross(omega_w, s_dir);
       const v_cm = mul(v_cm3, paramRadius);
 
       pos[0] += v_cm[0] * dtScaled;


### PR DESCRIPTION
Update coin rolling kinematics to use the full angular velocity for center-of-mass translation, correctly coupling its motion to the contact point.

Previously, the center-of-mass velocity was computed using only the component of angular velocity parallel to the coin's normal, which incorrectly decoupled the coin's translation from its full rotation and the instantaneous contact geometry. This change ensures the no-slip condition is strictly enforced at the contact point, resolving the "disentangled" motion from the plane.

---
<a href="https://cursor.com/background-agent?bcId=bc-225d75e8-4bdc-4b6d-90dc-d97d88638598">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-225d75e8-4bdc-4b6d-90dc-d97d88638598">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

