### PR TITLE
Fix slippery radius calculation

### DIFF
--- a/coin.html
+++ b/coin.html
@@ -211,9 +211,22 @@
       document.getElementById('timeScaleValue').textContent = Number(timeEl.value).toFixed(1);
     }
 
-    massEl.addEventListener('input', syncLabels);
-    radiusEl.addEventListener('input', syncLabels);
-    LEl.addEventListener('input', syncLabels);
+    // Live-apply parameter changes to maintain no-slip without requiring Reset
+    function applyNoSlipParams() {
+      paramMass = Number(massEl.value);
+      paramRadius = Number(radiusEl.value);
+      paramL = Number(LEl.value);
+      const I = momentOfInertia(paramMass, paramRadius);
+      omega = I > 0 ? (paramL / I) : 0; // ω = L / I
+      vx = omega * paramRadius;         // v = R · ω
+      // Keep the coin in contact with the ground as R changes
+      coinY = canvas.height - 60 - paramRadius;
+      syncLabels();
+    }
+
+    massEl.addEventListener('input', applyNoSlipParams);
+    radiusEl.addEventListener('input', applyNoSlipParams);
+    LEl.addEventListener('input', applyNoSlipParams);
     timeEl.addEventListener('input', () => { syncLabels(); paramTimeScale = Number(timeEl.value); });
 
     function toggleControls() {

--- a/index.html
+++ b/index.html
@@ -223,13 +223,27 @@
       document.getElementById('spinPhaseValue').textContent = Number(spinPhaseEl.value).toFixed(0);
     }
 
-    massEl.addEventListener('input', syncLabels);
-    radiusEl.addEventListener('input', syncLabels);
-    thicknessEl.addEventListener('input', syncLabels);
+    // Live-apply parameter changes so R and inertias affect ω and v immediately
+    function applyParametersLive(){
+      paramMass = Number(massEl.value);
+      paramRadius = Number(radiusEl.value);
+      paramThickness = Number(thicknessEl.value);
+      I_perp = inertiaTransverse(paramMass, paramRadius, paramThickness);
+      I_axis = inertiaAxial(paramMass, paramRadius);
+      // Allow L sliders to change constant world L interactively
+      L_world[0] = Number(LxEl.value);
+      L_world[1] = Number(LyEl.value);
+      L_world[2] = Number(LzEl.value);
+      syncLabels();
+    }
+
+    massEl.addEventListener('input', applyParametersLive);
+    radiusEl.addEventListener('input', applyParametersLive);
+    thicknessEl.addEventListener('input', applyParametersLive);
     timeEl.addEventListener('input', () => { paramTimeScale = Number(timeEl.value); syncLabels(); });
-    LxEl.addEventListener('input', syncLabels);
-    LyEl.addEventListener('input', syncLabels);
-    LzEl.addEventListener('input', syncLabels);
+    LxEl.addEventListener('input', () => { L_world[0] = Number(LxEl.value); syncLabels(); });
+    LyEl.addEventListener('input', () => { L_world[1] = Number(LyEl.value); syncLabels(); });
+    LzEl.addEventListener('input', () => { L_world[2] = Number(LzEl.value); syncLabels(); });
     tiltEl.addEventListener('input', syncLabels);
     headingEl.addEventListener('input', syncLabels);
     spinPhaseEl.addEventListener('input', syncLabels);


### PR DESCRIPTION
Update physics parameters live from sliders to immediately reflect changes in simulation, removing "slippery" behavior.

Previously, changing sliders for radius, mass, or angular momentum only updated their displayed labels, not the actual physics calculations (like velocity or inertia). This meant the coin's motion didn't adapt to the new parameters until a reset, leading to a "slippery" or unresponsive feel. This PR wires the sliders to recompute the relevant physics state (e.g., `omega = L/I`, `v = R*omega`) instantly, ensuring the simulation always matches the current slider values.

---
<a href="https://cursor.com/background-agent?bcId=bc-a71ec684-88a4-4b17-b325-31f028dde675">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a71ec684-88a4-4b17-b325-31f028dde675">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

